### PR TITLE
chore(ci): add `v` to tag

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -251,7 +251,7 @@ jobs:
       - uses: csexton/create-release@add-body
         id: create_release
         with:
-          tag_name: ${{ steps.versioning.outputs.cli_version }}
+          tag_name: v${{ steps.versioning.outputs.cli_version }}
           release_name: sn_cli
           draft: false
           prerelease: false

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3724,7 +3724,7 @@ dependencies = [
 
 [[package]]
 name = "sn_cli"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "ansi_term 0.9.0",
  "anyhow",


### PR DESCRIPTION
E.g. vx.x.x
This is what is expected by the install script, and it keeps this repo inline with others.